### PR TITLE
docs: add MIT License to clarify usage rights (#16)

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,21 +1,21 @@
 MIT License
 
-Copyright (c) 2025 pramisi
+Copyright (c) [2025] [Pramisi]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights  
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell     
-copies of the Software, and to permit persons to whom the Software is         
-furnished to do so, subject to the following conditions:                       
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.                               
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR    
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,      
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE   
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER        
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Designed for individuals who value **individuality, confidence, and quality**, O
 | JavaScript     | Website interactivity            |
 | Git & GitHub   | Version control & contributions  |
 
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
 ---
 
 ## 🤝 How to Contribute


### PR DESCRIPTION
Overview: This PR adds an MIT License to the root of the Occasio repository to clarify legal usage rights and promote open-source contributions. The absence of a license previously made it unclear how users and contributors could interact with the codebase—this update resolves that ambiguity.
Changes Made:
- ✅ Added LICENSE file with standard MIT License text
- 🛠️ Updated README.md with a "License" section and reference link.

close #16 
